### PR TITLE
config.toml: add link to RSS feed to sidebar menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,22 +16,18 @@ enableGitInfo = true
 
 [menu]
  [[menu.before]]
+  name = "RSS feed"
+  url = "/index.xml"
+  weight = 8
+ [[menu.before]]
   name = "Github"
   url = "https://github.com/mainec"
   weight = 9
-[[menu.before]]
+ [[menu.before]]
   name = "About"
   url = "/about"
   weight = 10
   post = '<div style="height: 20pt;"></div>'
-
-
-# needed for rss feed
-[outputs]
-  home = ['html', 'rss']
-  section = ['html', 'rss']
-  taxonomy = ['html']
-  term = ['html']
 
 
 [params]

--- a/local-server.sh
+++ b/local-server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Only required after initial checkout. Here to be on the safe side.
+git submodule init
+git submodule update
+
+# Render pages and start hugo server. The server will auto-update content on changes.
+hugo server --disableFastRender


### PR DESCRIPTION
This change adds a link to the site's rss feed (at "/index.xml") and removes unnecessary RSS configuration from config.toml.

Furthermore, a qol wrapper script for starting a local server (for development) was added.